### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#codeCanvas Desktop
+# codeCanvas Desktop
 
 This is an open source effort to create a community driven version of codeCanvas to run in App.js on the desktop.
 
-##Idea and goals
+## Idea and goals
 
 The application hosted at codeCanvas.org requires a good amount of server side file handling. My goal is to provide file handling in Node using the App.js framework.
 
-##Getting Started
+## Getting Started
 
 - Download App.js for your platform (Mac, Linux, Windows)
 - Place the codeCanvas files into the 'content' directory in app.js
@@ -15,12 +15,12 @@ The application hosted at codeCanvas.org requires a good amount of server side f
 - Check out the video -> building a simple form using a Bootstrap tool - http://youtu.be/7B5njAEy9Cs
                                                 
                                                                       
-##Structure
+## Structure
 
 - The application codebase is located in the 'app' directory
 - The user directory contains files needed to create tools (explained below)
 
-###User directory
+### User directory
 
 - usertools.html - this contains the html for the tools in your toolbox. The html construct is located inside a LI with the class "userTool". This allows you to create tool html naturally.
 
@@ -30,7 +30,7 @@ The application hosted at codeCanvas.org requires a good amount of server side f
 - usertools_design.css - This provides the styles for the tools while in the designer.  
 - usertools_run.css - This provides the styles your tool needs to work in a runtime environment
 
-##Participation
+## Participation
 
 The idea for this project came after many, many requests to open codeCanvas. It is far from perfect but the concept is working and just needs a good team of people to make it awesome.
 
@@ -41,7 +41,7 @@ We need people to help:
 - Write docs and do videos
 - Create a support forum
 
-##To Do
+## To Do
 
 a few things I am working on:
 
@@ -50,7 +50,7 @@ a few things I am working on:
 - specific tools for each project
 - building a 'default' set of templates for new projects
 
-##Contact
+## Contact
 
 You can contact me on the codeCanvas website
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
